### PR TITLE
Add SwiftUI example FRED chart app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "FredChartsApp",
+    platforms: [
+        .iOS(.v16)
+    ],
+    targets: [
+        .executableTarget(
+            name: "FredChartsApp",
+            path: "Sources/FredChartsApp")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# fred_ios
+# FredChartsApp
+
+This repository contains a simple SwiftUI iOS application that allows you to search the [FRED API](https://fred.stlouisfed.org/docs/api/fred/) for economic data series and plot the results using Apple's Charts framework.
+
+## Features
+
+- Search FRED series by keyword.
+- Display results in a list and select a series to view details.
+- Fetch observations for the selected series and draw a line chart.
+
+## Requirements
+
+- Xcode 15 or later with Swift 5.9+ (iOS 16 target).
+- A FRED API key available as an environment variable `FRED_API_KEY` when running the app.
+
+## Building
+
+The project is provided as a Swift Package. You can open the package in Xcode:
+
+```bash
+open Package.swift
+```
+
+Run the `FredChartsApp` scheme on an iOS simulator or device.
+
+## Notes
+
+The application uses `URLSession` to request data from the FRED API and relies on the `Charts` framework introduced in iOS 16. Ensure your deployment target is at least iOS 16.

--- a/Sources/FredChartsApp/AppState.swift
+++ b/Sources/FredChartsApp/AppState.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class AppState: ObservableObject {
+    @Published var searchText: String = ""
+    @Published var seriesList: [FREDSeries] = []
+    @Published var selectedSeries: FREDSeries?
+    @Published var observations: [FREDObservation] = []
+    
+    private let client: FREDClient
+    
+    init(apiKey: String) {
+        client = FREDClient(apiKey: apiKey)
+    }
+    
+    func search() async {
+        guard !searchText.isEmpty else { return }
+        do {
+            seriesList = try await client.searchSeries(query: searchText)
+        } catch {
+            print("Search error: \(error)")
+        }
+    }
+    
+    func load(series: FREDSeries) async {
+        selectedSeries = series
+        do {
+            observations = try await client.fetchObservations(seriesID: series.seriesID)
+        } catch {
+            print("Observation error: \(error)")
+        }
+    }
+}

--- a/Sources/FredChartsApp/ContentView.swift
+++ b/Sources/FredChartsApp/ContentView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import Charts
+
+struct ContentView: View {
+    @EnvironmentObject var state: AppState
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                HStack {
+                    TextField("Search", text: $state.searchText)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    Button("Go") {
+                        Task { await state.search() }
+                    }
+                }.padding()
+                List(state.seriesList) { series in
+                    NavigationLink(destination: SeriesDetailView(series: series)) {
+                        VStack(alignment: .leading) {
+                            Text(series.title)
+                            Text(series.seriesID).font(.caption).foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("FRED Browser")
+        }
+    }
+}
+
+struct SeriesDetailView: View {
+    @EnvironmentObject var state: AppState
+    let series: FREDSeries
+    var body: some View {
+        ScrollView {
+            if state.selectedSeries?.seriesID != series.seriesID {
+                ProgressView().task {
+                    await state.load(series: series)
+                }
+            } else {
+                Chart(state.observations) {
+                    LineMark(
+                        x: .value("Date", $0.date),
+                        y: .value("Value", Double($0.value) ?? 0)
+                    )
+                }
+                .chartXAxisLabel("Date")
+                .chartYAxisLabel("Value")
+                .frame(height: 300)
+            }
+        }
+        .navigationTitle(series.title)
+    }
+}
+
+#Preview {
+    ContentView().environmentObject(AppState(apiKey: "demo"))
+}

--- a/Sources/FredChartsApp/FREDClient.swift
+++ b/Sources/FredChartsApp/FREDClient.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct FREDSeries: Identifiable, Decodable {
+    var id: String { seriesID }
+    let seriesID: String
+    let title: String
+    
+    enum CodingKeys: String, CodingKey {
+        case seriesID = "id"
+        case title
+    }
+}
+
+struct FREDObservation: Identifiable, Decodable {
+    var id: String { date }
+    let date: String
+    let value: String
+}
+
+struct FREDSearchResponse: Decodable {
+    let seriess: [FREDSeries]
+}
+
+struct FREDObservationsResponse: Decodable {
+    let observations: [FREDObservation]
+}
+
+class FREDClient {
+    private let apiKey: String
+    private let session: URLSession
+    
+    init(apiKey: String, session: URLSession = .shared) {
+        self.apiKey = apiKey
+        self.session = session
+    }
+    
+    func searchSeries(query: String) async throws -> [FREDSeries] {
+        guard var comps = URLComponents(string: "https://api.stlouisfed.org/fred/series/search") else {
+            return []
+        }
+        comps.queryItems = [
+            URLQueryItem(name: "search_text", value: query),
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "file_type", value: "json")
+        ]
+        let (data, _) = try await session.data(from: comps.url!)
+        let response = try JSONDecoder().decode(FREDSearchResponse.self, from: data)
+        return response.seriess
+    }
+    
+    func fetchObservations(seriesID: String) async throws -> [FREDObservation] {
+        guard var comps = URLComponents(string: "https://api.stlouisfed.org/fred/series/observations") else {
+            return []
+        }
+        comps.queryItems = [
+            URLQueryItem(name: "series_id", value: seriesID),
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "file_type", value: "json")
+        ]
+        let (data, _) = try await session.data(from: comps.url!)
+        let response = try JSONDecoder().decode(FREDObservationsResponse.self, from: data)
+        return response.observations
+    }
+}

--- a/Sources/FredChartsApp/main.swift
+++ b/Sources/FredChartsApp/main.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct FredChartsApp: App {
+    @StateObject private var state = AppState(apiKey: ProcessInfo.processInfo.environment["FRED_API_KEY"] ?? "")
+    var body: some Scene {
+        WindowGroup {
+            ContentView().environmentObject(state)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Swift package for iOS app
- implement FRED API client and view model
- show SwiftUI views for searching FRED series and charting observations
- document build instructions

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684db7cd7044832dae21bde52e4bdb9c