### PR TITLE
Add simple FRED browser with charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# SimplePreviewApp
+# FRED iOS Browser
 
-This repository contains a minimal SwiftUI application packaged as a Swift Package.
-It shows a "Hello, world!" message and can be run as a preview in Xcode.
+This project is a simple SwiftUI application that lets you search the [FRED](https://fred.stlouisfed.org/) database and display a chart of a selected series.
+
+## Features
+- Search FRED series using the official API.
+- Browse results in a list.
+- Tap a series to view its observations plotted in a chart.
 
 ## Building
-
-Open the package in Xcode:
+Open the project in Xcode:
 
 ```bash
-open Package.swift
+open fred_ios.xcodeproj
 ```
 
-Run the `PreviewHostApp` scheme on an iOS simulator or use the SwiftUI preview.
+Add your FRED API key in `FredAPI.swift` by replacing `YOUR_API_KEY`.
+Run the `fred_ios` scheme on an iOS simulator or device.

--- a/fred_ios/ContentView.swift
+++ b/fred_ios/ContentView.swift
@@ -1,21 +1,73 @@
-//
-//  ContentView.swift
-//  fred_ios
-//
-//  Created by frank on 6/14/25.
-//
-
+import Charts
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = SearchViewModel()
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world! AAGH")
+        NavigationStack {
+            List {
+                ForEach(viewModel.results) { series in
+                    NavigationLink(series.title) {
+                        SeriesDetailView(series: series)
+                    }
+                }
+            }
+            .navigationTitle("FRED Browser")
+            .searchable(text: $viewModel.query)
+            .onChange(of: viewModel.query) { newValue in
+                Task { await viewModel.search() }
+            }
         }
-        .padding()
+    }
+}
+
+final class SearchViewModel: ObservableObject {
+    @Published var query: String = ""
+    @Published var results: [FredSeries] = []
+    
+    func search() async {
+        do {
+            let results = try await FredAPI.shared.searchSeries(query: query)
+            await MainActor.run { self.results = results }
+        } catch {
+            print("Search error", error)
+        }
+    }
+}
+
+struct SeriesDetailView: View {
+    let series: FredSeries
+    @State private var observations: [Observation] = []
+    
+    var body: some View {
+        ScrollView {
+            if observations.isEmpty {
+                ProgressView()
+                    .task { await load() }
+            } else {
+                Chart(observations) { obs in
+                    if let value = Double(obs.value) {
+                        LineMark(
+                            x: .value("Date", obs.date),
+                            y: .value("Value", value)
+                        )
+                    }
+                }
+                .frame(height: 300)
+                .padding()
+            }
+        }
+        .navigationTitle(series.title)
+    }
+    
+    private func load() async {
+        do {
+            let obs = try await FredAPI.shared.observations(for: series)
+            await MainActor.run { self.observations = obs }
+        } catch {
+            print("Obs error", error)
+        }
     }
 }
 

--- a/fred_ios/FredAPI.swift
+++ b/fred_ios/FredAPI.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftUI
+
+// Model representing a FRED series search result
+struct FredSeries: Identifiable, Decodable {
+    let id: String
+    let title: String
+    let frequency: String
+    let units: String
+    let lastUpdated: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "id"
+        case title
+        case frequency
+        case units
+        case lastUpdated = "last_updated"
+    }
+}
+
+struct SeriesSearchResponse: Decodable {
+    let seriess: [FredSeries]
+}
+
+struct Observation: Decodable, Identifiable {
+    let id = UUID()
+    let date: String
+    let value: String
+    
+    enum CodingKeys: String, CodingKey {
+        case date
+        case value
+    }
+}
+
+struct ObservationsResponse: Decodable {
+    let observations: [Observation]
+}
+
+final class FredAPI {
+    static let shared = FredAPI()
+    private init() {}
+    
+    // Replace with your own FRED API key
+    private let apiKey = "YOUR_API_KEY"
+    
+    func searchSeries(query: String) async throws -> [FredSeries] {
+        guard !query.isEmpty else { return [] }
+        var components = URLComponents(string: "https://api.stlouisfed.org/fred/series/search")!
+        components.queryItems = [
+            URLQueryItem(name: "search_text", value: query),
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "file_type", value: "json"),
+            URLQueryItem(name: "limit", value: "50")
+        ]
+        let (data, _) = try await URLSession.shared.data(from: components.url!)
+        let decoded = try JSONDecoder().decode(SeriesSearchResponse.self, from: data)
+        return decoded.seriess
+    }
+    
+    func observations(for series: FredSeries) async throws -> [Observation] {
+        var components = URLComponents(string: "https://api.stlouisfed.org/fred/series/observations")!
+        components.queryItems = [
+            URLQueryItem(name: "series_id", value: series.id),
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "file_type", value: "json")
+        ]
+        let (data, _) = try await URLSession.shared.data(from: components.url!)
+        let decoded = try JSONDecoder().decode(ObservationsResponse.self, from: data)
+        return decoded.observations
+    }
+}


### PR DESCRIPTION
## Summary
- implement FRED API wrapper and series/observations fetching
- add search UI and chart display using SwiftUI Charts
- update README with build instructions

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme fred_ios test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e681c0f2c832d89def1792b665a8b