### PR TITLE
Enhance charts and metadata display

### DIFF
--- a/fred_ios/FredAPI.swift
+++ b/fred_ios/FredAPI.swift
@@ -37,6 +37,16 @@ struct ObservationsResponse: Decodable {
     let observations: [Observation]
 }
 
+struct SeriesInfo: Decodable {
+    let id: String
+    let title: String
+    let notes: String
+}
+
+struct SeriesInfoResponse: Decodable {
+    let seriess: [SeriesInfo]
+}
+
 final class FredAPI {
     static let shared = FredAPI()
     private init() {}
@@ -68,5 +78,17 @@ final class FredAPI {
         let (data, _) = try await URLSession.shared.data(from: components.url!)
         let decoded = try JSONDecoder().decode(ObservationsResponse.self, from: data)
         return decoded.observations
+    }
+
+    func seriesInfo(id: String) async throws -> SeriesInfo? {
+        var components = URLComponents(string: "https://api.stlouisfed.org/fred/series")!
+        components.queryItems = [
+            URLQueryItem(name: "series_id", value: id),
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "file_type", value: "json")
+        ]
+        let (data, _) = try await URLSession.shared.data(from: components.url!)
+        let decoded = try JSONDecoder().decode(SeriesInfoResponse.self, from: data)
+        return decoded.seriess.first
     }
 }

--- a/fred_ios/LineChart.swift
+++ b/fred_ios/LineChart.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import DGCharts
 
-struct LineChart: UIViewRepresentable {
+private struct LineChartRepresentable: UIViewRepresentable {
     var observations: [Observation]
 
     func makeUIView(context: Context) -> LineChartView {
@@ -30,5 +30,20 @@ struct LineChart: UIViewRepresentable {
         uiView.data = LineChartData(dataSet: dataSet)
         uiView.xAxis.valueFormatter = IndexAxisValueFormatter(values: observations.map { $0.date })
         uiView.xAxis.granularity = 1
+    }
+}
+
+struct LineChart: View {
+    var observations: [Observation]
+    var yAxisLabel: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(yAxisLabel)
+                .font(.caption)
+                .rotationEffect(.degrees(-90))
+                .fixedSize()
+            LineChartRepresentable(observations: observations)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- improve line chart component with y-axis label
- show series metadata and link to the FRED website
- reduce navigation bar title size for better fit

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684efac27c00832d975ade7836ebc32b